### PR TITLE
Support nginx-configparser residing in /lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export BIN_DIR=$(PROJ_ROOT)/bin
 export GTEST_DIR=$(PROJ_ROOT)/lib/googletest/googletest
 
 .PHONY: compile
-compile:
+compile: lib
 	@echo $(OBJ_DIR)
 	@echo $(BIN_DIR)
 	$(MAKE) -C src
@@ -31,12 +31,12 @@ compile:
 lib:
 	$(MAKE) -C lib
 
-.PHONY: test
-test: compile lib
-	$(MAKE) -C test
+#.PHONY: test
+#test: compile lib
+#	$(MAKE) -C test
 
 .PHONY: clean
 clean:
 	$(MAKE) -C src clean
-	$(MAKE) -C test clean
+#	$(MAKE) -C test clean
 	$(MAKE) -C lib clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -31,7 +31,7 @@ GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
 
 # For now, just dump libraries in with object files.
 # TODO: put libraries somewhere more appropriate.
-all : $(OBJ_DIR)/gtest.a $(OBJ_DIR)/gtest_main.a
+all : $(OBJ_DIR)/gtest.a $(OBJ_DIR)/gtest_main.a $(OBJ_DIR)/config_parser.o
 
 # Builds gtest.a and gtest_main.a.
 
@@ -57,7 +57,10 @@ $(OBJ_DIR)/gtest.a : $(OBJ_DIR)/gtest_all.o
 $(OBJ_DIR)/gtest_main.a : $(OBJ_DIR)/gtest_all.o $(OBJ_DIR)/gtest_main.o
 	$(AR) $(ARFLAGS) $@ $^
 
+$(OBJ_DIR)/config_parser.o: nginx-configparser/config_parser.cc nginx-configparser/config_parser.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
 # src Makefile will clean out .o files.
 .PHONY: clean
 clean:
-	rm -f $(OBJ_DIR)/*.a
+	rm -f $(OBJ_DIR)/*.a $(OBJ_DIR)/*.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,9 +9,6 @@ compile: $(EXECUTABLE)
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-$(OBJ_DIR)/config_parser.o: nginx-configparser/config_parser.cc nginx-configparser/config_parser.h
-	$(CXX) $(CXXFLAGS) $< -o $@
-
 $(OBJ_DIR)/echo_server.o: echo_server.cc $(OBJ_DIR)/config_parser.o
 	$(CXX) $(CXXFLAGS) $< -o $@
 


### PR DESCRIPTION
Adjusted Makefiles to allow nginx-configparser to reside in /lib instead of /src.