### PR TITLE
Refactor code for improved testability

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -4,3 +4,17 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include "server.h"
+
+void Server::do_accept()
+{
+  acceptor_.async_accept(socket_,
+      [this](boost::system::error_code ec)
+      {
+      if (!ec)
+      {
+      std::make_shared<Session>(std::move(socket_))->start();
+      }
+
+      do_accept();
+      });
+}

--- a/src/server.h
+++ b/src/server.h
@@ -2,8 +2,6 @@
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
-// TODO refactor most of this code into server.cc
 
 #ifndef SERVER_INCLUDED
 #define SERVER_INCLUDED
@@ -27,19 +25,10 @@ class Server
   }
 
   private:
-    void do_accept()
-    {
-      acceptor_.async_accept(socket_,
-          [this](boost::system::error_code ec)
-          {
-          if (!ec)
-          {
-          std::make_shared<Session>(std::move(socket_))->start();
-          }
-
-          do_accept();
-          });
-    }
+    /*
+     * Allocate session for connection and listen for the next one.
+     */
+    void do_accept();
 
     tcp::acceptor acceptor_;
     tcp::socket socket_;

--- a/src/session.cc
+++ b/src/session.cc
@@ -4,3 +4,55 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include "session.h"
+
+void Session::do_read()
+{
+  auto self(shared_from_this());
+  socket_.async_read_some(boost::asio::buffer(data_, max_length),
+      [this, self](boost::system::error_code ec, std::size_t length)
+      {
+      if (!ec)
+      {
+      debugf("do_read got message of length %lu\n", length);
+      do_write(length);
+      }
+      });
+}
+
+void Session::do_write(std::size_t length)
+{
+  auto self(shared_from_this());
+  char *response = (char*) malloc(max_length);
+  if (response == NULL) {
+    debugf("do_write failed to allocate response buffer.\n");
+    return;
+  }
+
+  // Apparently boost doesn't care to null terminate its strings, so we
+  // have to do it ourselves.
+  if (length < max_length) {
+    data_[length] = 0;
+  } else {
+    // TODO: handle this
+    data_[max_length] = 0;
+  }
+
+  int response_len = snprintf(response, max_length, RESPONSE,
+      length, "text/plain", data_);
+
+  debugf("do_write sending response of length %d\n", response_len);
+
+  if (response_len >= max_length) {
+    // Output was truncated. TODO: handle this
+    debugf("do_write had to truncate response.\n");
+  }
+  boost::asio::async_write(socket_, boost::asio::buffer(response,
+        response_len),
+      [this, self](boost::system::error_code ec, std::size_t /*length*/)
+      {
+      if (!ec)
+      {
+      do_read();
+      }
+      });
+}

--- a/src/session.h
+++ b/src/session.h
@@ -2,8 +2,6 @@
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
-// TODO refactor most of this code into session.cc
 
 #ifndef SESSION_INCLUDED
 #define SESSION_INCLUDED
@@ -43,57 +41,12 @@ class Session
     /*
      * Read data from the client. On success, write back a response.
      */
-    void do_read()
-    {
-      auto self(shared_from_this());
-      socket_.async_read_some(boost::asio::buffer(data_, max_length),
-          [this, self](boost::system::error_code ec, std::size_t length)
-          {
-          if (!ec)
-          {
-          debugf("do_read got message of length %lu\n", length);
-          do_write(length);
-          }
-          });
-    }
+    void do_read();
 
-    void do_write(std::size_t length)
-    {
-      auto self(shared_from_this());
-      char *response = (char*) malloc(max_length);
-      if (response == NULL) {
-        debugf("do_write failed to allocate response buffer.\n");
-        return;
-      }
-
-      // Apparently boost doesn't care to null terminate its strings, so we
-      // have to do it ourselves.
-      if (length < max_length) {
-        data_[length] = 0;
-      } else {
-        // TODO: handle this
-        data_[max_length] = 0;
-      }
-
-      int response_len = snprintf(response, max_length, RESPONSE,
-          length, "text/plain", data_);
-
-      debugf("do_write sending response of length %d\n", response_len);
-
-      if (response_len >= max_length) {
-        // Output was truncated. TODO: handle this
-        debugf("do_write had to truncate response.\n");
-      }
-      boost::asio::async_write(socket_, boost::asio::buffer(response,
-            response_len),
-          [this, self](boost::system::error_code ec, std::size_t /*length*/)
-          {
-          if (!ec)
-          {
-          do_read();
-          }
-          });
-    }
+    /*
+     * Write data to the client. On success, listen for more data.
+     */
+    void do_write(std::size_t length);
 
     tcp::socket socket_;
     enum { max_length = 65536 }; // TODO: why is this an enum?

--- a/src/session.h
+++ b/src/session.h
@@ -44,13 +44,19 @@ class Session
     void do_read();
 
     /*
-     * Write data to the client. On success, listen for more data.
+     * Process data received from the client, and choose the appropriate
+     * response handler. For now this just calls do_write.
      */
-    void do_write(std::size_t length);
+    void process_response(std::size_t length);
+
+    /*
+     * Write msg to the client. On success, listen for more data.
+     */
+    void do_write(const char *msg, std::size_t length);
 
     tcp::socket socket_;
-    enum { max_length = 65536 }; // TODO: why is this an enum?
-    char data_[max_length];
+    static const std::size_t MAX_LENGTH = 65536;
+    char data_[MAX_LENGTH];
 };
 
 #endif


### PR DESCRIPTION
Refactored Sessions so that IO is more cleanly separated from text processing, adding the process_response method to go between do_read and do_write. This should make the more sensitive part of the echo server - response preparation - more easily testable.

Also pulled nontrivial method definitions out of server.h and session.h, putting them into .cc files.